### PR TITLE
add support for named exports in curly braces

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function run(filepath, isMode) {
 
 	if (keys.length > 0) {
 		keys.sort().forEach(key => {
-			CJS += `\nexports.${key} = ${key};`;
+			CJS += `\nmodule.exports.${key} = ${key};`;
 		});
 	}
 

--- a/index.js
+++ b/index.js
@@ -118,17 +118,13 @@ function run(filepath, isMode) {
 	const isDefault = /export default/.test(ESM);
 
 	let CJS = imports(ESM)
-		.replace(/(^|\s|;)export default/, '$1var __defaultExport =')
+		.replace(/(^|\s|;)export default/, '$1module.exports =')
 		.replace(/(^|\s|;)export (const|(?:async )?function|class|let|var) (.+?)(?=(\(|\s|\=))/gi, (_, x, type, name) => {
 			return keys.push(name) && `${x}${type} ${name}`;
 		})
 		.replace(/(^|\s|;)export \{(.+?)}(?=(;|\s|$))/, (_, x, names) => {
-			return keys.push(...(names.split(',').map(name => name.trim()))) && '';
+			return keys.push(...(names.split(',').map(name => name.trim()))) && x;
 		});
-
-	if (isDefault) {
-		CJS += `\nmodule.exports = __defaultExport;\nmodule.exports.default = __defaultExport;`
-	}
 
 	if (keys.length > 0) {
 		keys.sort().forEach(key => {

--- a/index.js
+++ b/index.js
@@ -121,6 +121,9 @@ function run(filepath, isMode) {
 		.replace(/(^|\s|;)export default/, '$1module.exports =')
 		.replace(/(^|\s|;)export (const|(?:async )?function|class|let|var) (.+?)(?=(\(|\s|\=))/gi, (_, x, type, name) => {
 			return keys.push(name) && `${x}${type} ${name}`;
+		})
+		.replace(/(^|\s|;)export \{(.+?)}(?=(;|\s|$))/, (_, x, names) => {
+			return keys.push(...(names.split(',').map(name => name.trim()))) && x;
 		});
 
 	if (keys.length > 0) {

--- a/index.js
+++ b/index.js
@@ -118,13 +118,17 @@ function run(filepath, isMode) {
 	const isDefault = /export default/.test(ESM);
 
 	let CJS = imports(ESM)
-		.replace(/(^|\s|;)export default/, '$1module.exports =')
+		.replace(/(^|\s|;)export default/, '$1var __defaultExport =')
 		.replace(/(^|\s|;)export (const|(?:async )?function|class|let|var) (.+?)(?=(\(|\s|\=))/gi, (_, x, type, name) => {
 			return keys.push(name) && `${x}${type} ${name}`;
 		})
 		.replace(/(^|\s|;)export \{(.+?)}(?=(;|\s|$))/, (_, x, names) => {
-			return keys.push(...(names.split(',').map(name => name.trim()))) && x;
+			return keys.push(...(names.split(',').map(name => name.trim()))) && '';
 		});
+
+	if (isDefault) {
+		CJS += `\nmodule.exports = __defaultExport;\nmodule.exports.default = __defaultExport;`
+	}
 
 	if (keys.length > 0) {
 		keys.sort().forEach(key => {

--- a/test/fixtures/curly-named-exports/expects.json
+++ b/test/fixtures/curly-named-exports/expects.json
@@ -1,0 +1,5 @@
+{
+  "cjs": "dist/curly-named.js",
+  "esm": "dist/curly-named.mjs",
+  "umd": "dist/curly-named.min.js"
+}

--- a/test/fixtures/curly-named-exports/package.json
+++ b/test/fixtures/curly-named-exports/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "named-exports",
+  "unpkg": "dist/curly-named.min.js",
+  "module": "dist/curly-named.mjs",
+  "main": "dist/curly-named.js"
+}

--- a/test/fixtures/curly-named-exports/src/index.js
+++ b/test/fixtures/curly-named-exports/src/index.js
@@ -1,0 +1,19 @@
+function foo(a) {
+	return a + a;
+}
+
+const bar = b => b + b;
+
+async function baz(a) {
+	return a + a;
+}
+
+let hello = 'world';
+
+var abc = 123;
+
+class Foo extends Component {
+	//
+}
+
+export { foo, bar, baz, hello, abc, Foo };

--- a/test/index.js
+++ b/test/index.js
@@ -14,7 +14,7 @@ const fixtures = join(__dirname, 'fixtures');
 
 const tests = {
 	cjs: /(module\.)?exports(\.?)/,
-	esm: /export (default )?(function|const|class|let|var)/,
+	esm: /export ((default )?(function|const|class|let|var)|{)/,
 	umd: new RegExp(`"object"==typeof exports&&"undefined"!=typeof module`)
 };
 


### PR DESCRIPTION
This adds support for named exports like the following:

```js
export { foo };
```

~~It also aliases the default export - if there's any - to `module.exports.default` for TypeScript interoperability without requiring the `esModuleInterop` option.~~ Dropped this part from the PR after the conversation in lukeed/klona#17.