### PR TITLE
Fix accidentally trying to read .terserrc when package.json has "terser" field

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ if (argv.length > 0) {
 
 const name = pkg['umd:name'] || pkg.name;
 const mount = /(.|-|@)/.test(name) ? `['${name}']` : `.${name}`;
-const terser = pkg.terser || existsSync(rcfile) ? JSON.parse(readFileSync(rcfile)) : {};
+const terser = pkg.terser || (existsSync(rcfile) ? JSON.parse(readFileSync(rcfile)) : {});
 
 function capitalize(str) {
 	return str[0].toUpperCase() + str.substring(1);


### PR DESCRIPTION
When `package.json` has a `"terser"` field the code tries to read a potentially non-existent .terserrc file instead of using the value of the field

Looks like it was just an operator precedence issue!