### PR TITLE
chore: update terser to 5.8

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function size(val=0) {
 	return out + ' ' + UNITS[exp];
 }
 
-function write(file, data, isUMD, toDir) {
+async function write(file, data, isUMD, toDir) {
 	file = normalize(file);
 	let isDef = /\.d\.ts$/.test(file);
 	if (isDef && toDir !== 'default') {
@@ -41,7 +41,7 @@ function write(file, data, isUMD, toDir) {
 	}
 	mkdir(dirname(file)); // sync
 	let code = isDef && data;
-	code = code || minify(data, Object.assign({ toplevel:!isUMD }, terser)).code;
+	code = code || (await minify(data, Object.assign({ toplevel:!isUMD }, terser))).code;
 	writeFileSync(file, isUMD ? code : data);
 	let gzip = size(gzipSync(code).length);
 	return { file, size: size(code.length), gzip };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "kleur": "^4.0.0",
     "mk-dirs": "^3.0.0",
     "rewrite-imports": "^3.0.0",
-    "terser": "^4.8.0"
+    "terser": "^5.8.0"
   },
   "devDependencies": {
     "premove": "3.0.1",


### PR DESCRIPTION
Looking at the [changelog](https://github.com/terser/terser/blob/master/CHANGELOG.md) between 4.8-5.8 looks like the only breaking change that matters for `bundt` is that `minify` becomes async.